### PR TITLE
Fix PWRKEY pulse to turn on modem

### DIFF
--- a/src/IoT_BASE_SIM7080.h
+++ b/src/IoT_BASE_SIM7080.h
@@ -23,4 +23,5 @@ void iotBaseInit() {
     delay(2000);
     digitalWrite(IoT_BASE_SIM7080_EN, HIGH);
     delay(500);
+    digitalWrite(IoT_BASE_SIM7080_EN, LOW);
 };


### PR DESCRIPTION
The SIM7080 PWRKEY requires a pulse high - low - high. However the IoT Base incorporates an inverter (transistor) therefore IoT_BASE_SIM7080_EN needs to be driven low - high - low.

Note: the current implementation where IoT_BASE_SIM7080_EN stays high (PWRKEY low) causes the modem to reset every 12 seconds.